### PR TITLE
Hacklang property typehint support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
   - 5.6
   - nightly
   - hhvm
-  - hhvm-nightly
 
 matrix:
     allow_failures:
@@ -28,3 +27,4 @@ install:
 
 script:
   - vendor/bin/phpspec run
+  - vendor/bin/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,17 @@
       "PropertyInfo\\": "src/PropertyInfo"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "PropertyInfo\\Tests\\": "tests"
+    }
+  },
   "require": {
     "php": ">=5.4"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.1",
+    "phpunit/phpunit": "~4.5",
     "doctrine/orm": "~2.3",
     "phpdocumentor/reflection": "~1.0"
   },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,5 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+        bootstrap="tests/bootstrap.php">
+</phpunit>

--- a/src/PropertyInfo/Extractors/GetterExtractor.php
+++ b/src/PropertyInfo/Extractors/GetterExtractor.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Extractors;
+
+use PropertyInfo\Type;
+
+/**
+ * Getter Extractor.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class GetterExtractor extends NativeExtractor
+{
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return array|Type[]
+     */
+    public function extractTypes(\ReflectionProperty $property)
+    {
+        $typeInfo = $this->typeInfoParser->getGetterReturnType($property);
+
+        return $this->typeInfoParser->parse($typeInfo);
+    }
+}

--- a/src/PropertyInfo/Extractors/NativeExtractor.php
+++ b/src/PropertyInfo/Extractors/NativeExtractor.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Extractors;
+
+use PropertyInfo\TypeExtractorInterface;
+use PropertyInfo\TypeInfoParsers\HhvmTypeInfoParser;
+use PropertyInfo\TypeInfoParsers\PhpTypeInfoParser;
+
+/**
+ * Native Extractor.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+abstract class NativeExtractor implements TypeExtractorInterface
+{
+    /**
+     * @var  PhpTypeInfoParser|HhvmTypeInfoParser
+     */
+    protected $typeInfoParser;
+
+    public function __construct()
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->typeInfoParser = new HhvmTypeInfoParser();
+        } else {
+            $this->typeInfoParser = new PhpTypeInfoParser();
+        }
+    }
+}

--- a/src/PropertyInfo/Extractors/PhpDocExtractor.php
+++ b/src/PropertyInfo/Extractors/PhpDocExtractor.php
@@ -102,7 +102,8 @@ class PhpDocExtractor implements DescriptionExtractorInterface, TypeExtractorInt
      */
     private function getFileReflector(\ReflectionClass $reflectionClass)
     {
-        if (!($fileName = $reflectionClass->getFileName())) {
+        if (!($fileName = $reflectionClass->getFileName())
+        || in_array(pathinfo($fileName, PATHINFO_EXTENSION), ['php7', 'hh'])) {
             return;
         }
 

--- a/src/PropertyInfo/Extractors/PropertyExtractor.php
+++ b/src/PropertyInfo/Extractors/PropertyExtractor.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Extractors;
+
+use PropertyInfo\Type;
+
+/**
+ * Property Extractor.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class PropertyExtractor extends NativeExtractor
+{
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return array|Type[]
+     */
+    public function extractTypes(\ReflectionProperty $property)
+    {
+        $typeInfo = $this->typeInfoParser->getPropertyType($property);
+
+        return $this->typeInfoParser->parse($typeInfo);
+    }
+}

--- a/src/PropertyInfo/Extractors/SetterExtractor.php
+++ b/src/PropertyInfo/Extractors/SetterExtractor.php
@@ -10,48 +10,23 @@
 namespace PropertyInfo\Extractors;
 
 use PropertyInfo\Type;
-use PropertyInfo\TypeExtractorInterface;
 
 /**
  * Setter Extractor.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class SetterExtractor implements TypeExtractorInterface
+class SetterExtractor extends NativeExtractor
 {
+    /**
+     * @param \ReflectionProperty $reflectionProperty
+     *
+     * @return array|Type[]|null
+     */
     public function extractTypes(\ReflectionProperty $reflectionProperty)
     {
-        $setterName = sprintf('set%s', ucfirst($reflectionProperty->getName()));
-        $reflectionClass = $reflectionProperty->getDeclaringClass();
+        $typeInfo = $this->typeInfoParser->getSetterParamType($reflectionProperty);
 
-        if ($reflectionClass->hasMethod($setterName)) {
-            $reflectionMethod = $reflectionClass->getMethod($setterName);
-            if (1 !== $reflectionMethod->getNumberOfRequiredParameters()) {
-                return;
-            }
-
-            foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
-                if ($reflectionParameter->isOptional()) {
-                    continue;
-                }
-
-                $type = new Type();
-                if ($reflectionParameter->isArray()) {
-                    $type->setCollection(true);
-                    $type->setType('array');
-                } elseif ($reflectionParameter->isCallable()) {
-                    $type->setCollection(false);
-                    $type->setType('callable');
-                } elseif ($typeHint = $reflectionParameter->getClass()) {
-                    $type->setCollection(false);
-                    $type->setType('object');
-                    $type->setClass($typeHint->getName());
-                } else {
-                    return;
-                }
-
-                return [$type];
-            }
-        }
+        return $this->typeInfoParser->parse($typeInfo);
     }
 }

--- a/src/PropertyInfo/TypeInfoParserInterface.php
+++ b/src/PropertyInfo/TypeInfoParserInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo;
+
+/**
+ *     Type info parser interface. Implementing classes of this interface should be able to retrieve information about a
+ * property based on the given \ReflectionProperty.
+ *
+ *     The information returned should be a string representation of the type information.
+ *
+ *     Implementing classes should also be able to parse this string and return Type[] objects based on the it.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+interface TypeInfoParserInterface
+{
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getPropertyType(\ReflectionProperty $property);
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getGetterReturnType(\ReflectionProperty $property);
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getSetterParamType(\ReflectionProperty $property);
+
+    /**
+     * @param string $info
+     *
+     * @return array|Type[]
+     */
+    public function parse($info);
+}

--- a/src/PropertyInfo/TypeInfoParsers/HhvmTypeInfoParser.php
+++ b/src/PropertyInfo/TypeInfoParsers/HhvmTypeInfoParser.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\TypeInfoParsers;
+
+use PropertyInfo\Type;
+
+/**
+ *     This class will extract type information available to HHVM from Properties, Getters and Setter parameters and it
+ * will parse said information into Type[] objects.
+ *
+ *     HHVM has full type hinting (including scalars) and it is available for properties, Getter return types, and
+ * Setter parameter types.
+ *
+ *     Known limitation: when parsing type information we can correctly identify array<int, string> or Vector<stdClass>
+ * but we do not (currently) parse recursively in depth so we cannot correctly identify array<int, array<string>>.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class HhvmTypeInfoParser extends NativeTypeInfoParser
+{
+    protected static $types = array(
+        'HH\\bool' => 'bool',
+        'HH\\int' => 'int',
+        'HH\\float' => 'float',
+        'HH\\double' => 'float',
+        'HH\\string' => 'string',
+        'callable' => 'callable',
+        'array' => 'array',
+    );
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getPropertyType(\ReflectionProperty $property)
+    {
+        return $property->getTypeText() ?: null;
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getGetterReturnType(\ReflectionProperty $property)
+    {
+        $method = $this->getGetter($property);
+
+        return $method->getReturnTypeText();
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getSetterParamType(\ReflectionProperty $property)
+    {
+        $param = $this->getSetterParam($property);
+        if (null !== $param) {
+            return $param->getTypeText();
+        }
+    }
+
+    /**
+     * @param string $info
+     *
+     * @return array|Type[]
+     */
+    public function parse($info)
+    {
+        if ('?' === $info[0]) {
+            $info = substr($info, 1);
+        }
+
+        if (($type = $this->parseSimpleTypes($info)) || ($type = $this->parseContainerTypes($info))) {
+            return [$type];
+        }
+    }
+
+    /**
+     * @param string $info
+     *
+     * @return Type|null
+     */
+    public function parseSimpleTypes($info)
+    {
+        $type = new Type();
+
+        if (isset(static::$types[$info])) {
+            $type->setType(static::$types[$info]);
+            $type->setCollection('array' === $info);
+        } elseif (class_exists($info, true)) {
+            $class = new \ReflectionClass($info);
+            $collection = $class->implementsInterface('HH\\Collection');
+
+            $type->setType('object');
+            $type->setClass($info);
+            $type->setCollection($collection);
+        } else {
+            $type = null;
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param string $info
+     *
+     * @return Type|null
+     */
+    protected function parseContainerTypes($info)
+    {
+        $type = new Type();
+
+        if (false !== ($pos = strpos($info, '<'))) {
+            $container = substr($info, 0, $pos);
+            $contents = substr($info, $pos+1, -1);
+            $contents = explode(', ', $contents);
+
+            if ('array' === $container) {
+                $types = $this->parse(end($contents));
+                $type = reset($types);
+                $type->setCollection(true);
+
+                $type->setCollectionType(new Type());
+                $type->getCollectionType()->setType('array');
+                $type->getCollectionType()->setCollection(false);
+            } elseif (class_exists($container, true)) {
+                $types = $this->parse(end($contents));
+                $type = reset($types);
+                $collectionTypes = $this->parse($container);
+                $type->setCollectionType(reset($collectionTypes));
+
+                if ($type->getCollectionType()->isCollection()) {
+                    $type->setCollection(true);
+                    $type->getCollectionType()->setCollection(false);
+                } else {
+                    $type->setCollectionType(null);
+                }
+            }
+        } else {
+            $type = null;
+        }
+
+        return $type;
+    }
+}

--- a/src/PropertyInfo/TypeInfoParsers/NativeTypeInfoParser.php
+++ b/src/PropertyInfo/TypeInfoParsers/NativeTypeInfoParser.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\TypeInfoParsers;
+
+use PropertyInfo\TypeInfoParserInterface;
+
+/**
+ *    This abstract supplies a few helper functions for reusable retrieval of reflection data associated with a
+ * \ReflectionProperty objects.
+ *
+ *    For example it will retrieve the \ReflectionMethod of a Getter associated with a particular \ReflectionProperty.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+abstract class NativeTypeInfoParser implements TypeInfoParserInterface
+{
+    const GETTER_FORMAT = 'get%s';
+    const SETTER_FORMAT = 'set%s';
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return \ReflectionMethod|null
+     */
+    public function getGetter(\ReflectionProperty $property)
+    {
+        $getter = sprintf(static::GETTER_FORMAT, ucfirst($property->getName()));
+        $class = $property->getDeclaringClass();
+        if ($class->hasMethod($getter)) {
+            return $class->getMethod($getter);
+        }
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return \ReflectionMethod|null
+     */
+    public function getSetter(\ReflectionProperty $property)
+    {
+        $setter = sprintf(static::SETTER_FORMAT, ucfirst($property->getName()));
+        $class = $property->getDeclaringClass();
+        if ($class->hasMethod($setter)) {
+            return $class->getMethod($setter);
+        }
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return \ReflectionParameter|null
+     */
+    public function getSetterParam(\ReflectionProperty $property)
+    {
+        $setter = $this->getSetter($property);
+        if (null === $setter or 1 !== $setter->getNumberOfRequiredParameters()) {
+            return null;
+        }
+
+        $params = $setter->getParameters();
+        foreach ($params as $param) {
+            if ($param->isOptional()) {
+                continue;
+            }
+
+            return $param;
+        }
+    }
+}

--- a/src/PropertyInfo/TypeInfoParsers/PhpTypeInfoParser.php
+++ b/src/PropertyInfo/TypeInfoParsers/PhpTypeInfoParser.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\TypeInfoParsers;
+
+use PropertyInfo\Type;
+
+/**
+ *     This class will extract type information available to PHP from Properties, Getters and Setter parameters and it
+ * will parse said information into Type[] objects.
+ *
+ *     Based on the current PHP version more information will be available (ex.: PHP7 has scalar type hinting and Getter
+ * return types which are not available in PHP5).
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class PhpTypeInfoParser extends NativeTypeInfoParser
+{
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getPropertyType(\ReflectionProperty $property)
+    {
+        return null;
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getGetterReturnType(\ReflectionProperty $property)
+    {
+        $getter = $this->getGetter($property);
+
+        if (PHP_VERSION >= 7 && $getter !== null && $getter->hasReturnType()) {
+            return (string) $getter->getReturnType();
+        }
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     *
+     * @return string|null
+     */
+    public function getSetterParamType(\ReflectionProperty $property)
+    {
+        $param = $this->getSetterParam($property);
+        if (null !== $param) {
+            if (PHP_VERSION >= 7) {
+                return (string) $param->getType();
+            } elseif ($param->isArray()) {
+                return 'array';
+            } elseif ($param->isCallable()) {
+                return 'callable';
+            } elseif ($class = $param->getClass()) {
+                return $class->getName();
+            }
+        }
+    }
+
+
+    /**
+     * @param string $info
+     *
+     * @return array|Type[]|null
+     */
+    public function parse($info)
+    {
+        $type = new Type();
+
+        $collection = false;
+        $class = null;
+
+        if ($info === null) {
+            return null;
+        } elseif ($info === 'double') {
+            $info = 'float';
+        } elseif ($info === 'array') {
+            $collection = true;
+        } elseif (class_exists($info)) {
+            $class = $info;
+            $info = 'object';
+        }
+
+        $type->setCollection($collection);
+        $type->setType($info);
+        $type->setClass($class);
+
+        return [$type];
+    }
+}

--- a/tests/DoctrineExtractors/Data/DoctrineDummy.php
+++ b/tests/DoctrineExtractors/Data/DoctrineDummy.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\DoctrineExtractors\Data;
+
+/**
+ * @Entity
+ */
+class DoctrineDummy
+{
+    /**
+     * @Id
+     * @Column(type="smallint")
+     */
+    public $id;
+    /**
+     * @ManyToOne(targetEntity="DoctrineRelation")
+     */
+    public $foo;
+    /**
+     * @ManyToMany(targetEntity="DoctrineRelation")
+     */
+    public $bar;
+    /**
+     * @Column(type="guid")
+     */
+    protected $guid;
+    /**
+     * @Column(type="time")
+     */
+    private $time;
+    /**
+     * @Column(type="json_array")
+     */
+    private $json;
+    /**
+     * @Column(type="boolean")
+     */
+    private $bool;
+    /**
+     * @Column(type="binary")
+     */
+    private $binary;
+
+    public $notMapped;
+}

--- a/tests/DoctrineExtractors/Data/DoctrineRelation.php
+++ b/tests/DoctrineExtractors/Data/DoctrineRelation.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\DoctrineExtractors\Data;
+
+/**
+ * @Entity
+ */
+class DoctrineRelation
+{
+    /**
+     * @Id
+     * @Column(type="smallint")
+     */
+    public $id;
+}

--- a/tests/DoctrineExtractors/DoctrineExtractorTest.php
+++ b/tests/DoctrineExtractors/DoctrineExtractorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\DoctrineExtractors;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\Setup;
+use PropertyInfo\Extractors\DoctrineExtractor;
+use PropertyInfo\PropertyInfo;
+use PropertyInfo\Tests\DoctrineExtractors\Data\DoctrineDummy;
+use PropertyInfo\Type;
+use PropertyInfo\TypeExtractorInterface;
+
+/**
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    public function extractorsDataProvider()
+    {
+        $properties = array(
+            array(
+                'name'       => 'id',
+                'type'       => 'int',
+                'collection' => false,
+                'class'      => null,
+            ),
+            array(
+                'name'       => 'guid',
+                'type'       => 'string',
+                'collection' => false,
+                'class'      => null,
+            ),
+            array(
+                'name'       => 'bool',
+                'type'       => 'bool',
+                'collection' => false,
+                'class'      => null,
+            ),
+            array('name' => 'binary', 'type' => 'resource', 'collection' => false, 'class' => null),
+            array('name' => 'json', 'type' => 'array', 'collection' => true, 'class' => null),
+            array('name' => 'foo', 'type' => 'object', 'collection' => false, 'class' => 'PropertyInfo\Tests\DoctrineExtractors\Data\DoctrineRelation'),
+            array(
+                'name'           => 'bar',
+                'type'           => 'object',
+                'collection'     => true,
+                'class'          => 'Doctrine\Common\Collections\Collection',
+                'collectionType' => array('type' => 'object', 'collection' => false, 'class' => 'PropertyInfo\Tests\DoctrineExtractors\Data\DoctrineRelation'),
+            ),
+            array('name' => 'notMapped', 'type' => null, 'collection' => false, 'class' => null),
+    );
+
+        $cases = array(
+            array('PropertyInfo\Tests\DoctrineExtractors\Data\DoctrineDummy', 'PropertyInfo\Extractors\DoctrineExtractor', $properties),
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider extractorsDataProvider
+     *
+     * @param $class
+     * @param $extractor
+     * @param $properties
+     */
+    public function testExtractors($class, $extractor, $properties)
+    {
+        $config = Setup::createAnnotationMetadataConfiguration([__DIR__], true);
+        $entityManager = EntityManager::create(['driver' => 'pdo_sqlite'], $config);
+
+        /** @var TypeExtractorInterface $extractor */
+        $extractor = new $extractor($entityManager->getMetadataFactory());
+        $propertyInfo = new PropertyInfo([$extractor], []);
+
+        foreach ($properties as $property) {
+            $reflectionProperty = new \ReflectionProperty($class, $property['name']);
+
+            $expectedType = $property['type'];
+            /** @var Type[] $actualTypes */
+            $actualTypes = $propertyInfo->getTypes($reflectionProperty);
+            $actualType = $actualTypes[0];
+
+            if ($expectedType !== null) {
+                $this->assertEquals($expectedType, $actualType->getType());
+                $this->assertEquals($property['class'], $actualType->getClass());
+                $this->assertEquals($property['collection'], $actualType->isCollection());
+
+                if (isset($property['collectionType'])) {
+                    $actualCollectionType = $actualType->getCollectionType();
+                    $this->assertEquals($property['collectionType']['type'], $actualCollectionType->getType());
+                    $this->assertEquals($property['collectionType']['class'], $actualCollectionType->getClass());
+                    $this->assertEquals(
+                        $property['collectionType']['collection'],
+                        $actualCollectionType->isCollection()
+                    );
+                }
+            } else {
+                $this->assertNull($actualType);
+            }
+        }
+    }
+}

--- a/tests/NativeExtractors/Data/HackData.hh
+++ b/tests/NativeExtractors/Data/HackData.hh
@@ -1,0 +1,340 @@
+<?hh
+//strict
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors\Data;
+
+/**
+ *    This exemplifies many combinations of typed property definitions with getters and setters. It
+  is inspected by Property, Getter and Setter extractors during tests.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class HackData
+{
+    private bool $bool = true;
+    private int $int = 0;
+    private float $float = 0.0;
+    private string $string = '';
+    private array $array = array();
+    private \stdClass $object;
+
+    private ?bool $boolNullable;
+    private ?int $intNullable;
+    private ?float $floatNullable;
+    private ?string $stringNullable;
+    private ?array $arrayNullable;
+    private ?\stdClass $objectNullable;
+
+    private array<bool> $boolArray = array();
+    private array<int> $intArray = array();
+    private array<float> $floatArray = array();
+    private array<string> $stringArray = array();
+    private array<array> $arrayArray = array();
+    private array<\stdClass> $objectArray = array();
+
+    private array<int, bool> $boolArrayInt = array();
+    private array<int, int> $intArrayInt = array();
+    private array<int, float> $floatArrayInt = array();
+    private array<int, string> $stringArrayInt = array();
+    private array<int, array> $arrayArrayInt = array();
+    private array<int, \stdClass> $objectArrayInt = array();
+
+    private ?Vector<bool> $boolVector;
+    private ?Vector<int> $intVector;
+    private ?Vector<float> $floatVector;
+    private ?Vector<string> $stringVector;
+    private ?Vector<array> $arrayVector;
+    private ?Vector<\stdClass> $objectVector;
+
+    public function __construct()
+    {
+        $this->object = new \stdClass();
+    }
+
+
+    public function getBool(): bool
+    {
+        return $this->bool;
+    }
+    public function setBool(bool $bool)
+    {
+        $this->bool = $bool;
+    }
+
+    public function getInt(): int
+    {
+        return $this->int;
+    }
+    public function setInt(int $int)
+    {
+        $this->int = $int;
+    }
+
+    public function getFloat(): float
+    {
+        return $this->float;
+    }
+    public function setFloat(float $float)
+    {
+        $this->float = $float;
+    }
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+    public function setString(string $string)
+    {
+        $this->string = $string;
+    }
+
+    public function getArray(): array
+    {
+        return $this->array;
+    }
+    public function setArray(array $array)
+    {
+        $this->array = $array;
+    }
+
+    public function getObject(): \stdClass
+    {
+        return $this->object;
+    }
+    public function setObject(\stdClass $object)
+    {
+        $this->object = $object;
+    }
+
+    public function getBoolNullable(): ?bool
+    {
+        return $this->boolNullable;
+    }
+    public function setBoolNullable(?bool $boolNullable)
+    {
+        $this->boolNullable = $boolNullable;
+    }
+
+    public function getIntNullable(): ?int
+    {
+        return $this->intNullable;
+    }
+    public function setIntNullable(?int $intNullable)
+    {
+        $this->intNullable = $intNullable;
+    }
+
+    public function getFloatNullable(): ?float
+    {
+        return $this->floatNullable;
+    }
+    public function setFloatNullable(?float $floatNullable)
+    {
+        $this->floatNullable = $floatNullable;
+    }
+
+
+    public function getStringNullable(): ?string
+    {
+        return $this->stringNullable;
+    }
+    public function setStringNullable(?string $stringNullable)
+    {
+        $this->stringNullable = $stringNullable;
+    }
+
+    public function getArrayNullable(): ?array
+    {
+        return $this->arrayNullable;
+    }
+    public function setArrayNullable(?array $arrayNullable)
+    {
+        $this->arrayNullable = $arrayNullable;
+    }
+
+    public function getObjectNullable(): ?\stdClass
+    {
+        return $this->objectNullable;
+    }
+    public function setObjectNullable(?\stdClass $objectNullable)
+    {
+        $this->objectNullable = $objectNullable;
+    }
+
+
+    public function getBoolArray(): array<bool>
+    {
+        return $this->boolArray;
+    }
+    public function setBoolArray(array<bool> $boolArray)
+    {
+        $this->boolArray = $boolArray;
+    }
+
+    public function getIntArray(): array<int>
+    {
+        return $this->intArray;
+    }
+    public function setIntArray(array<int> $intArray)
+    {
+        $this->intArray = $intArray;
+    }
+
+    public function getFloatArray(): array<float>
+    {
+        return $this->floatArray;
+    }
+    public function setFloatArray(array<float> $floatArray)
+    {
+        $this->floatArray = $floatArray;
+    }
+
+
+    public function getStringArray(): array<string>
+    {
+        return $this->stringArray;
+    }
+    public function setStringArray(array<string> $stringArray)
+    {
+        $this->stringArray = $stringArray;
+    }
+
+    public function getArrayArray(): array<array>
+    {
+        return $this->arrayArray;
+    }
+
+    public function setArrayArray(array<array> $arrayArray)
+    {
+        $this->arrayArray = $arrayArray;
+    }
+
+    public function getObjectArray(): array<\stdClass>
+    {
+        return $this->objectArray;
+    }
+    public function setObjectArray(array<\stdClass> $objectArray)
+    {
+        $this->objectArray = $objectArray;
+    }
+
+
+    public function getBoolArrayInt(): array<int, bool>
+    {
+        return $this->boolArrayInt;
+    }
+    public function setBoolArrayInt(array<int, bool> $boolArrayInt)
+    {
+        $this->boolArrayInt = $boolArrayInt;
+    }
+
+    public function getIntArrayInt(): array<int, int>
+    {
+        return $this->intArrayInt;
+    }
+    public function setIntArrayInt(array<int, int> $intArrayInt)
+    {
+        $this->intArrayInt = $intArrayInt;
+    }
+
+    public function getFloatArrayInt(): array<int, float>
+    {
+        return $this->floatArrayInt;
+    }
+    public function setFloatArrayInt(array<int, float> $floatArrayInt)
+    {
+        $this->floatArrayInt = $floatArrayInt;
+    }
+
+
+    public function getStringArrayInt(): array<int, string>
+    {
+        return $this->stringArrayInt;
+    }
+    public function setStringArrayInt(array<int, string> $stringArrayInt)
+    {
+        $this->stringArrayInt = $stringArrayInt;
+    }
+
+    public function getArrayArrayInt(): array<int, array>
+    {
+        return $this->arrayArrayInt;
+    }
+
+    public function setArrayArrayInt(array<int, array> $arrayArrayInt)
+    {
+        $this->arrayArrayInt = $arrayArrayInt;
+    }
+
+    public function getObjectArrayInt(): array<int, \stdClass>
+    {
+        return $this->objectArrayInt;
+    }
+    public function setObjectArrayInt(array<int, \stdClass> $objectArrayInt)
+    {
+        $this->objectArrayInt = $objectArrayInt;
+    }
+
+
+    public function getBoolVector(): ?Vector<bool>
+    {
+        return $this->boolVector;
+    }
+    public function setBoolVector(?Vector<bool> $boolVector)
+    {
+        $this->boolVector = $boolVector;
+    }
+
+    public function getIntVector(): ?Vector<int>
+    {
+        return $this->intVector;
+    }
+    public function setIntVector(?Vector<int> $intVector)
+    {
+        $this->intVector = $intVector;
+    }
+
+    public function getFloatVector(): ?Vector<float>
+    {
+        return $this->floatVector;
+    }
+    public function setFloatVector(?Vector<float> $floatVector)
+    {
+        $this->floatVector = $floatVector;
+    }
+
+
+    public function getStringVector(): ?Vector<string>
+    {
+        return $this->stringVector;
+    }
+    public function setStringVector(?Vector<string> $stringVector)
+    {
+        $this->stringVector = $stringVector;
+    }
+
+    public function getArrayVector(): ?Vector<array>
+    {
+        return $this->arrayVector;
+    }
+    public function setArrayVector(?Vector<array> $arrayVector)
+    {
+        $this->arrayVector = $arrayVector;
+    }
+
+    public function getObjectVector(): ?Vector<\stdClass>
+    {
+        return $this->objectVector;
+    }
+    public function setObjectVector(?Vector<\stdClass> $objectVector)
+    {
+        $this->objectVector = $objectVector;
+    }
+}

--- a/tests/NativeExtractors/Data/Php5Data.php
+++ b/tests/NativeExtractors/Data/Php5Data.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors\Data;
+
+/**
+ *    This exemplifies property definitions with typed setters. It is inspected by Getter and Setter extractors during
+ * tests.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class Php5Data
+{
+    private $array;
+    private $callable;
+    private $object;
+
+    public function setArray(array $array)
+    {
+        $this->array = $array;
+    }
+
+    public function setCallable(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    public function setObject(\stdClass $object)
+    {
+        $this->object = $object;
+    }
+}

--- a/tests/NativeExtractors/Data/Php7Data.php
+++ b/tests/NativeExtractors/Data/Php7Data.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors\Data;
+
+/**
+ *    This exemplifies many combinations of property definitions with typed getters and setters. It is inspected by
+ * Getter and Setter extractors during tests.
+ *
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class Php7Data extends Php5Data
+{
+    private $bool;
+    private $int;
+    private $float;
+    private $string;
+    private $array;
+    private $callable;
+    private $object;
+
+
+    public function getBool(): bool
+    {
+        return $this->bool;
+    }
+    public function setBool(bool $bool)
+    {
+        $this->bool = $bool;
+    }
+
+    public function getInt(): int
+    {
+        return $this->int;
+    }
+    public function setInt(int $int)
+    {
+        $this->int = $int;
+    }
+
+    public function getFloat(): float
+    {
+        return $this->float;
+    }
+    public function setFloat(float $float)
+    {
+        $this->float = $float;
+    }
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+    public function setString(string $string)
+    {
+        $this->string = $string;
+    }
+
+    public function getArray(): array
+    {
+        return $this->array;
+    }
+
+    public function getCallable(): callable
+    {
+        return $this->callable;
+    }
+
+    public function getObject(): \stdClass
+    {
+        return $this->object;
+    }
+}

--- a/tests/NativeExtractors/DataProviders/HackDataProvider.hh
+++ b/tests/NativeExtractors/DataProviders/HackDataProvider.hh
@@ -1,0 +1,63 @@
+<?hh
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors\DataProviders;
+
+use PropertyInfo\Extractors\PropertyExtractor;
+use PropertyInfo\Extractors\SetterExtractor;
+use PropertyInfo\Extractors\GetterExtractor;
+use PropertyInfo\Tests\NativeExtractors\Data\HackData;
+
+/**
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class HackDataProvider
+{
+    /**
+     * @return array
+     */
+    public function extractorsDataProvider()
+    {
+        $properties = [
+            ['name' => 'bool', 'type' => 'bool', 'class' => null],
+            ['name' => 'int', 'type' => 'int', 'class' => null],
+            ['name' => 'float', 'type' => 'float', 'class' => null],
+            ['name' => 'string', 'type' => 'string', 'class' => null],
+            ['name' => 'array', 'type' => 'array', 'class' => null],
+            ['name' => 'object', 'type' => 'object', 'class' => 'stdClass'],
+        ];
+
+        $extra = $properties;
+        foreach ($properties as $property) {
+            $property['name'] = $property['name'] . 'Nullable';
+            $extra[] = $property;
+        }
+        foreach ($properties as $property) {
+            $property['name'] = $property['name'] . 'Array';
+            $extra[] = $property;
+        }
+        foreach ($properties as $property) {
+            $property['name'] = $property['name'] . 'ArrayInt';
+            $extra[] = $property;
+        }
+        foreach ($properties as $property) {
+            $property['name'] = $property['name'] . 'Vector';
+            $extra[] = $property;
+        }
+        $properties = $extra;
+
+        $cases = [
+            [HackData::class, PropertyExtractor::class, $properties],
+            [HackData::class, GetterExtractor::class, $properties],
+            [HackData::class, SetterExtractor::class, $properties],
+        ];
+
+        return $cases;
+    }
+}

--- a/tests/NativeExtractors/DataProviders/Php5DataProvider.php
+++ b/tests/NativeExtractors/DataProviders/Php5DataProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors\DataProviders;
+
+use PropertyInfo\Extractors\SetterExtractor;
+use PropertyInfo\Tests\NativeExtractors\Data\Php5Data;
+
+/**
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class Php5DataProvider
+{
+    /**
+     * @return array
+     */
+    public function extractorsDataProvider()
+    {
+        $properties = [
+            ['name' => 'array', 'type' => 'array', 'class' => null],
+            ['name' => 'callable', 'type' => 'callable', 'class' => null],
+            ['name' => 'object', 'type' => 'object', 'class' => 'stdClass'],
+        ];
+
+        $cases = [
+            [
+                'PropertyInfo\Tests\NativeExtractors\Data\Php5Data',
+                'PropertyInfo\Extractors\SetterExtractor',
+                $properties
+            ],
+        ];
+
+        return $cases;
+    }
+}

--- a/tests/NativeExtractors/DataProviders/Php7DataProvider.php
+++ b/tests/NativeExtractors/DataProviders/Php7DataProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors\DataProviders;
+
+use PropertyInfo\Extractors\SetterExtractor;
+use PropertyInfo\Extractors\GetterExtractor;
+use PropertyInfo\Tests\NativeExtractors\Data\Php7Data;
+
+/**
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class Php7DataProvider
+{
+    /**
+     * @return array
+     */
+    public function extractorsDataProvider()
+    {
+        $properties = [
+            ['name' => 'bool', 'type' => 'bool', 'class' => null],
+            ['name' => 'int', 'type' => 'int', 'class' => null],
+            ['name' => 'float', 'type' => 'float', 'class' => null],
+            ['name' => 'string', 'type' => 'string', 'class' => null],
+            ['name' => 'array', 'type' => 'array', 'class' => null],
+            ['name' => 'callable', 'type' => 'callable', 'class' => null],
+            ['name' => 'object', 'type' => 'object', 'class' => 'stdClass'],
+        ];
+
+        $cases = [
+            [Php7Data::class, GetterExtractor::class, $properties],
+            [Php7Data::class, SetterExtractor::class, $properties],
+        ];
+
+        return $cases;
+    }
+}

--- a/tests/NativeExtractors/NativeExtractorTest.php
+++ b/tests/NativeExtractors/NativeExtractorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\NativeExtractors;
+
+use PropertyInfo\PropertyInfo;
+use PropertyInfo\Tests\NativeExtractors\DataProviders\HackDataProvider;
+use PropertyInfo\Tests\NativeExtractors\DataProviders\Php5DataProvider;
+use PropertyInfo\Tests\NativeExtractors\DataProviders\Php7DataProvider;
+
+/**
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class NativeExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    public function extractorsDataProvider()
+    {
+        if (defined('HHVM_VERSION')) {
+            $data = new HackDataProvider();
+        } elseif (PHP_VERSION >= 7) {
+            $data = new Php7DataProvider();
+        } else {
+            $data = new Php5DataProvider();
+        }
+
+        return $data->extractorsDataProvider();
+    }
+
+    /**
+     * @dataProvider extractorsDataProvider
+     *
+     * @param $class
+     * @param $extractor
+     * @param $properties
+     */
+    public function testExtractors($class, $extractor, $properties)
+    {
+        $extractor = new $extractor();
+        $propertyInfo = new PropertyInfo([$extractor], []);
+
+        foreach ($properties as $property) {
+            $expectedType = $property['type'];
+            $actualTypes = $propertyInfo->getTypes(new \ReflectionProperty($class, $property['name']));
+
+            if (null !== $actualTypes) {
+                $this->assertCount(1, $actualTypes);
+
+                $actualType = $actualTypes[0];
+
+                $this->assertEquals($expectedType, $actualType->getType());
+
+                if (!empty($property['class'])) {
+                    $this->assertEquals($property['class'], $actualType->getClass());
+                }
+            } else {
+                $this->fail(
+                    vsprintf(
+                        'Using "%1$s" type "%2$s" resulted in an empty type list',
+                        array(get_class($extractor), $expectedType)
+                    )
+                );
+            }
+        }
+    }
+}

--- a/tests/PhpDocExtractors/Data/PhpDocDummy.php
+++ b/tests/PhpDocExtractors/Data/PhpDocDummy.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\PhpDocExtractors\Data;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class PhpDocDummy extends PhpDocParent
+{
+    /**
+     * @var string This is bar.
+     */
+    private $bar;
+    /**
+     * Should be used.
+     *
+     * @var int Should be ignored.
+     */
+    protected $baz;
+    /**
+     * @var \DateTime
+     */
+    public $bal;
+    /**
+     * @var PhpDocParent
+     */
+    public $parent;
+    /**
+     * @var \DateTime[]
+     */
+    public $collection;
+}

--- a/tests/PhpDocExtractors/Data/PhpDocParent.php
+++ b/tests/PhpDocExtractors/Data/PhpDocParent.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\PhpDocExtractors\Data;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class PhpDocParent
+{
+    /**
+     * Short description.
+     *
+     * Long description.
+     */
+    public $foo;
+    /**
+     * @var float
+     */
+    public $foo2;
+    /**
+     * @var callback
+     */
+    public $foo3;
+    /**
+     * @var void
+     */
+    public $foo4;
+    /**
+     * @var mixed
+     */
+    public $foo5;
+    /**
+     * @var \SplFileInfo[]|resource
+     */
+    public $files;
+}

--- a/tests/PhpDocExtractors/PhpDocExtractorTest.php
+++ b/tests/PhpDocExtractors/PhpDocExtractorTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PropertyInfo\Tests\PhpDocExtractors;
+
+use PropertyInfo\DescriptionExtractorInterface;
+use PropertyInfo\PropertyInfo;
+use PropertyInfo\Type;
+use PropertyInfo\TypeExtractorInterface;
+
+/**
+ * @author Mihai Stancu <stancu.t.mihai@gmail.com>
+ */
+class PhpDocExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    public function extractorsDataProvider()
+    {
+        $properties = [
+            [
+                'name'              => 'foo',
+                'type'              => null,
+                'collection'        => false,
+                'class'             => null,
+                'short_description' => 'Short description.',
+                'long_description'  => 'Long description.',
+            ],
+            [
+                'name'              => 'bar',
+                'type'              => 'string',
+                'collection'        => false,
+                'class'             => null,
+                'short_description' => 'This is bar.',
+            ],
+            [
+                'name'              => 'baz',
+                'type'              => 'int',
+                'collection'        => false,
+                'class'             => null,
+                'short_description' => 'Should be used.',
+            ],
+            ['name' => 'foo2', 'type' => 'float', 'collection' => false, 'class' => null],
+            ['name' => 'foo3', 'type' => 'callable', 'collection' => false, 'class' => null],
+            ['name' => 'foo4', 'type' => 'null', 'collection' => false, 'class' => null],
+            ['name' => 'foo5', 'type' => null, 'collection' => false, 'class' => null],
+            [
+                'name'           => 'files',
+                'type'           => 'array',
+                'collection'     => true,
+                'class'          => null,
+                'collectionType' => ['type' => 'object', 'collection' => false, 'class' => 'SplFileInfo'],
+            ],
+            ['name' => 'bal', 'type' => 'object', 'collection' => false, 'class' => 'DateTime'],
+            [
+                'name'       => 'parent',
+                'type'       => 'object',
+                'collection' => false,
+                'class'      => 'PropertyInfo\Tests\PhpDocExtractors\Data\PhpDocParent',
+            ],
+            [
+                'name'           => 'collection',
+                'type'           => 'array',
+                'collection'     => true,
+                'class'          => null,
+                'collectionType' => ['type' => 'object', 'collection' => false, 'class' => 'DateTime'],
+            ],
+        ];
+
+        $cases = [
+            [
+                'PropertyInfo\Tests\PhpDocExtractors\Data\PhpDocDummy',
+                'PropertyInfo\Extractors\PhpDocExtractor',
+                $properties,
+            ],
+        ];
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider extractorsDataProvider
+     *
+     * @param $class
+     * @param $extractor
+     * @param $properties
+     */
+    public function testExtractors($class, $extractor, $properties)
+    {
+        /** @var TypeExtractorInterface|DescriptionExtractorInterface $extractor */
+        $extractor = new $extractor();
+        $propertyInfo = new PropertyInfo([$extractor], [$extractor]);
+
+        foreach ($properties as $property) {
+            $reflectionProperty = new \ReflectionProperty($class, $property['name']);
+
+            $expectedType = $property['type'];
+            /** @var Type[] $actualTypes */
+            $actualTypes = $propertyInfo->getTypes($reflectionProperty);
+            $actualType = $actualTypes[0];
+
+
+            if (isset($property['short_description'])) {
+                $this->assertEquals(
+                    $property['short_description'],
+                    $propertyInfo->getShortDescription($reflectionProperty)
+                );
+            }
+            if (isset($property['long_description'])) {
+                $this->assertEquals(
+                    $property['long_description'],
+                    $propertyInfo->getLongDescription($reflectionProperty)
+                );
+            }
+
+            if ($expectedType !== null) {
+                $this->assertEquals($expectedType, $actualType->getType());
+                $this->assertEquals($property['class'], $actualType->getClass());
+                $this->assertEquals($property['collection'], $actualType->isCollection());
+
+                if (isset($property['collectionType'])) {
+                    $actualCollectionType = $actualType->getCollectionType();
+                    $this->assertEquals($property['collectionType']['type'], $actualCollectionType->getType());
+                    $this->assertEquals($property['collectionType']['class'], $actualCollectionType->getClass());
+                    $this->assertEquals(
+                        $property['collectionType']['collection'],
+                        $actualCollectionType->isCollection()
+                    );
+                }
+            } else {
+                $this->assertNull($actualType);
+            }
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+require_once(__DIR__ . '/../vendor/autoload.php');


### PR DESCRIPTION
Hi,

I have implemented:
- type-hint support for Hack Properties, Getters and Setters;
- type-hint support for PHP7 Getters and Setters;
- refactored PHP5 type-hint support for Setters so that PHP5, PHP7 and Hack all use the same Extractor but with different type-info parsers;

Tested using `phpunit` -- sorry but I don't have experience with `phpspec` yet.

N.B.: PhpDocExtractor needs to be disabled for *.hh files because it expects PHP syntax and things break so I touched that extractor too, to limit its reach on parsing files.
