### PR TITLE
Travis improve

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ trim_trailing_whitespace = true
 [*.php]
 indent_style = space
 indent_size = 4
+
+[composer.json]
+indent_style = space
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,18 @@ php:
   - hhvm
 
 matrix:
-    allow_failures:
-        - php: nightly
-        - php: hhvm-nightly
-    fast_finish: true
+  include:
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
+  allow_failures:
+    - php: nightly
+    - php: hhvm-nightly
+  fast_finish: true
 
 before_script:
-    - composer self-update
-
-install:
-  - composer install --dev
+  - composer self-update
+  - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
   - vendor/bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,48 @@
 {
-  "name": "dunglas/php-property-info",
-  "type": "library",
-  "description": "Retrieve type and description of PHP properties using various sources ",
-  "keywords": [
-    "property",
-    "type",
-    "PHPDoc",
-    "symfony",
-    "validator",
-    "doctrine"
-  ],
-  "homepage": "http://dunglas.fr",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Kévin Dunglas",
-      "email": "dunglas@gmail.com"
+    "name": "dunglas/php-property-info",
+    "type": "library",
+    "description": "Retrieve type and description of PHP properties using various sources ",
+    "keywords": [
+        "property",
+        "type",
+        "PHPDoc",
+        "symfony",
+        "validator",
+        "doctrine"
+    ],
+    "homepage": "http://dunglas.fr",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Kévin Dunglas",
+            "email": "dunglas@gmail.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "PropertyInfo\\": "src/PropertyInfo"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PropertyInfo\\Tests\\": "tests"
+        }
+    },
+    "require": {
+        "php": ">=5.4"
+    },
+    "require-dev": {
+        "phpspec/phpspec": "~2.1",
+        "phpunit/phpunit": "~4.5",
+        "doctrine/orm": "~2.3",
+        "phpdocumentor/reflection": "~1.0"
+    },
+    "conflict": {
+        "phpdocumentor/reflection": "<1.0.4"
+    },
+    "suggest": {
+        "doctrine/orm": "To use Doctrine metadata",
+        "symfony/validator": "To use Symfony validator metadata",
+        "phpdocumentor/reflection": "To use the PHPDoc"
     }
-  ],
-  "autoload": {
-    "psr-4": {
-      "PropertyInfo\\": "src/PropertyInfo"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "PropertyInfo\\Tests\\": "tests"
-    }
-  },
-  "require": {
-    "php": ">=5.4"
-  },
-  "require-dev": {
-    "phpspec/phpspec": "~2.1",
-    "phpunit/phpunit": "~4.5",
-    "doctrine/orm": "~2.3",
-    "phpdocumentor/reflection": "~1.0"
-  },
-  "conflict": {
-    "phpdocumentor/reflection": "<1.0.4"
-  },
-  "suggest": {
-    "doctrine/orm": "To use Doctrine metadata",
-    "symfony/validator": "To use Symfony validator metadata",
-    "phpdocumentor/reflection": "To use the PHPDoc"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
     "doctrine/orm": "~2.3",
     "phpdocumentor/reflection": "~1.0"
   },
+  "conflict": {
+    "phpdocumentor/reflection": "<1.0.4"
+  },
   "suggest": {
     "doctrine/orm": "To use Doctrine metadata",
     "symfony/validator": "To use Symfony validator metadata",


### PR DESCRIPTION
- Introduce `Makefile` for test and later another rules
- Test with lowest dependencies with composer
- Remove deprecated `--dev` composer option
- Introduce `GITHUB_OAUTH_TOKEN` to get and cache composer dist packages
- Remove phpspec from dependencies to install it from global

Note: You have to set up a Github token on secure `GITHUB_OAUTH_TOKEN` Travis env var. This token need no special permissions and will not appears on PR.

I'll make another proposition about CS once this PR get merged.

Regards
